### PR TITLE
Allow email/key information to be stored as environment variables

### DIFF
--- a/R/aqs_user.R
+++ b/R/aqs_user.R
@@ -3,11 +3,20 @@
 ##' @param email Email address of user
 ##' @param key Key phrase of user
 ##' @details The AQS API requires an email address and key for all queries. The key is not used for authentication (as in a password), but it is used for identification.
+##' @details The email and key can be stored as environment variables as AQS_EMAIL and AQS_KEY, respectively, rather than specified as function arguments.
 ##' @return \code{create_user} returns a list containing the email and key.
 ##' @seealso \code{\link{aqs_get}}
 ##' @export
 create_user <- function(email,
-                     key){
+                        key) {
+    if(missing(email)) {
+        email <- Sys.getenv("AQS_EMAIL")
+        if(!nzchar(email))
+            stop("need AQS email address identifier")
+        key <- Sys.getenv("AQS_KEY")
+        if(!nzchar(key))
+            stop("need AQS key")
+    }
     list(email=email,
          key=key)
 }

--- a/aqsr.Rproj
+++ b/aqsr.Rproj
@@ -18,3 +18,4 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace

--- a/man/create_user.Rd
+++ b/man/create_user.Rd
@@ -25,6 +25,8 @@ Create user-key object for accessing AQS API
 \details{
 The AQS API requires an email address and key for all queries. The key is not used for authentication (as in a password), but it is used for identification.
 
+The email and key can be stored as environment variables as AQS_EMAIL and AQS_KEY, respectively, rather than specified as function arguments.
+
 Use \code{aqs_signup} to register an email and obtain a key phrase. The key value is emailed to the provided address, it is not return directly from the API.
 }
 \seealso{


### PR DESCRIPTION
I edited the create_user() function to allow the email and key information to be read from environment variables AQS_EMAIL and AQS_KEY via the Sys.getenv() function. This way, people don't have to put their email and key directly into code (and then accidentally send it to GitHub or something like that). They can just stick it in their .Renviron file.